### PR TITLE
Add launchSettings to run web apps as consoles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ dlldata.c
 project.lock.json
 project.fragment.lock.json
 artifacts/
-**/Properties/launchSettings.json
 
 *_i.c
 *_p.c

--- a/Marketing.Api/Properties/launchSettings.json
+++ b/Marketing.Api/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Marketing.Api": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:55189/"
+    }
+  }
+}

--- a/Sales.Api/Properties/launchSettings.json
+++ b/Sales.Api/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Sales.Api": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:55187/"
+    }
+  }
+}

--- a/SimpleEShop.UI/Properties/launchSettings.json
+++ b/SimpleEShop.UI/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "SimpleEShop.UI": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:56039/"
+    }
+  }
+}

--- a/Warehouse.Api/Properties/launchSettings.json
+++ b/Warehouse.Api/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "Warehouse.Api": {
+      "commandName": "Project",
+      "launchBrowser": false,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:55188/"
+    }
+  }
+}


### PR DESCRIPTION
Adding a `launchSettings.json` file to each web project allows to configure how the web app is hosted, for demos hosting as a console app is a better approach since it removes the dependency on IIS / IIS Express.
I also configured all web app, but `SimpleEShop.UI`, to NOT open a web browser, so that at <kbd>F5</kbd> time 4 console apps will be run and 1 single web page will be displayed.